### PR TITLE
[#142683997] revert adding note for 1.8.2 since it is not released yet

### DIFF
--- a/release-notes.html.md.erb
+++ b/release-notes.html.md.erb
@@ -2,13 +2,6 @@
 title: Push Notification Service Release Notes
 ---
 
-##v1.8.2
-**Release Date: April 2017**
-
-**Bug fixes**
-
-Addressed MariaDB migration issue when installing push on PCF 1.10.0
-
 ##v1.8.1
 **Release Date: March 2017**
 


### PR DESCRIPTION
Sorry for this as Push tile 1.8.2 has not released yet. 

Signed-off-by: Rui Yang <ryang@pivotal.io>