### PR TITLE
Started DevOps Monitoring section

### DIFF
--- a/devops.html.md.erb
+++ b/devops.html.md.erb
@@ -2,6 +2,35 @@
 title: DevOps
 ---
 
+## <a id="monitoring"></a> Monitoring
+
+### Healthcheck
+
+Push provides a healthcheck endpoint which can be polled for monitoring the health of both Push and it's connection to dependencies. The endpoint can be found at `http://healthcheck.push-api.pcf-top-level-domain.`
+
+A sample output of the healthcheck endpoint:
+
+```
+{
+  "database": {
+          "healthy": true,
+          "message": "MySQL"
+  },
+  "rabbitmq": {
+          "healthy": true,
+          "message": "All rabbit nodes (ingest, dispatch, push, audit) are running"
+   },
+   "scheduler-backend": {
+          "healthy": true,
+          "message": "Scheduler is up"
+   }
+}
+```
+### Heartbeat Monitoring
+
+At installation time, a pre-configured heartbeat monitor mobile app is created which will send a regular push notification through the system to a mobile device. See the top level sections on configuring heartbeat monitor for iOS and Android.
+
+
 ## <a id="uninstalling"></a> Uninstalling
 
 **IMPORTANT**


### PR DESCRIPTION
After customer feedback that there is no published method for monitoring the Push service, this section was added to document the healthcheck endpoint and remind customers about heartbeat monitoring.